### PR TITLE
New/pre filter

### DIFF
--- a/calculator_of_Onmyoji/cal_and_filter.py
+++ b/calculator_of_Onmyoji/cal_and_filter.py
@@ -5,10 +5,10 @@ import itertools
 from calculator_of_Onmyoji import data_format
 
 
-def filter_loc2make_combination(data_dict,
-                                l2_prop, l2_value,
-                                l4_prop, l4_value,
-                                l6_prop, l6_value):
+def filter_loc(data_dict,
+                l2_prop, l2_value,
+                l4_prop, l4_value,
+                l6_prop, l6_value):
     if len(data_dict) != 6:
         raise KeyError("combination dict source must have 6 keys")
 
@@ -26,7 +26,63 @@ def filter_loc2make_combination(data_dict,
     print('after filter by loc prop %s %s %s %s %s %s' % (len(d1), len(d2),
                                                           len(d3), len(d4),
                                                           len(d5), len(d6)))
-    return itertools.product(d1, d2, d3, d4, d5, d6)
+    return dict(zip(range(1,7), [d1, d2, d3, d4, d5, d6]))
+
+
+def make_combination(mitama_data, mitama_type_limit={}, all_suit=True):
+    main_type, secondary_type = None, None
+    for m_type in mitama_type_limit:
+        if mitama_type_limit[m_type] == 4:
+            main_type = m_type
+        elif mitama_type_limit[m_type] == 2:
+            secondary_type = m_type
+
+    def filter_mitama_by_type(mitama, desired_type):
+        mitama_info = mitama.values()[0]
+        if (mitama_info[u'御魂类型'] == desired_type):
+            return True
+        else:
+            return False
+
+    if not main_type:
+        return itertools.product(*mitama_data.values())
+    else:
+        #separate the main type mitamas and all other mitamas
+        main_mitama = dict(zip(range(1,7), [None]*6))
+        other_mitama = dict(zip(range(1,7), [None]*6))
+        for i in range(1, 7):
+            main_mitama[i] = filter(lambda x: filter_mitama_by_type(x, main_type), mitama_data[i])
+            other_mitama[i] = filter(lambda x: not filter_mitama_by_type(x, main_type), mitama_data[i])
+
+        if secondary_type:
+            secondary_mitama = dict(zip(range(1,7), [None]*6))
+            for i in range(1, 7):
+                secondary_mitama[i] = filter(lambda x: filter_mitama_by_type(x, secondary_type), mitama_data[i])
+
+        res = []
+        res.append(itertools.product(*main_mitama.values()))
+
+        #4+2
+        for i in range(1, 7):
+            for j in range(i, 7):
+                mitama_grp = {i: main_mitama[i] for i in range(1,7)}
+                if secondary_type:
+                    mitama_grp[i] = secondary_mitama[i]
+                    mitama_grp[j] = secondary_mitama[j]
+                else:
+                    mitama_grp[i] = other_mitama[i]
+                    mitama_grp[j] = other_mitama[j]
+                res.append(itertools.product(*mitama_grp.values()))
+
+        #5+1
+        if not (all_suit or secondary_type):
+            for i in range(1, 7):
+                mitama_grp = {x: main_mitama[x] for x in range(1,7)}
+                mitama_grp[i] = other_mitama[i]
+                res.append(itertools.product(*mitama_grp.values()))
+
+        
+        return itertools.chain(*res)
 
 
 def filter_loc_prop(data_list, prop_type, prop_min_value):

--- a/calculator_of_Onmyoji/cal_and_filter.py
+++ b/calculator_of_Onmyoji/cal_and_filter.py
@@ -29,8 +29,10 @@ def filter_loc(data_dict,
     return dict(zip(range(1,7), [d1, d2, d3, d4, d5, d6]))
 
 
+
 def make_combination(mitama_data, mitama_type_limit={}, all_suit=True):
     main_type, secondary_type = None, None
+    total_comb = 0
     for m_type in mitama_type_limit:
         if mitama_type_limit[m_type] == 4:
             main_type = m_type
@@ -45,6 +47,8 @@ def make_combination(mitama_data, mitama_type_limit={}, all_suit=True):
             return False
 
     if not main_type:
+        total_comb = reduce(lambda x,y: x*y, map(len, mitama_data.values()))
+        print("Total combinations: {}".format(total_comb))
         return itertools.product(*mitama_data.values())
     else:
         #separate the main type mitamas and all other mitamas
@@ -60,18 +64,20 @@ def make_combination(mitama_data, mitama_type_limit={}, all_suit=True):
                 secondary_mitama[i] = filter(lambda x: filter_mitama_by_type(x, secondary_type), mitama_data[i])
 
         res = []
+        total_comb += reduce(lambda x,y: x*y, map(len, main_mitama.values()))
         res.append(itertools.product(*main_mitama.values()))
 
         #4+2
         for i in range(1, 7):
             for j in range(i, 7):
-                mitama_grp = {i: main_mitama[i] for i in range(1,7)}
+                mitama_grp = {x: main_mitama[x] for x in range(1,7)}
                 if secondary_type:
                     mitama_grp[i] = secondary_mitama[i]
                     mitama_grp[j] = secondary_mitama[j]
                 else:
                     mitama_grp[i] = other_mitama[i]
                     mitama_grp[j] = other_mitama[j]
+                total_comb += reduce(lambda x,y: x*y, map(len, mitama_grp.values()))
                 res.append(itertools.product(*mitama_grp.values()))
 
         #5+1
@@ -79,9 +85,10 @@ def make_combination(mitama_data, mitama_type_limit={}, all_suit=True):
             for i in range(1, 7):
                 mitama_grp = {x: main_mitama[x] for x in range(1,7)}
                 mitama_grp[i] = other_mitama[i]
+                total_comb += reduce(lambda x,y: x*y, map(len, mitama_grp.values()))
                 res.append(itertools.product(*mitama_grp.values()))
 
-        
+        print("Total combinations: {}".format(total_comb))
         return itertools.chain(*res)
 
 

--- a/calculator_of_Onmyoji/cal_and_filter.py
+++ b/calculator_of_Onmyoji/cal_and_filter.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 
 import itertools
-
 from calculator_of_Onmyoji import data_format
 
 
@@ -27,7 +26,6 @@ def filter_loc(data_dict,
                                                           len(d3), len(d4),
                                                           len(d5), len(d6)))
     return dict(zip(range(1,7), [d1, d2, d3, d4, d5, d6]))
-
 
 
 def make_combination(mitama_data, mitama_type_limit={}, all_suit=True):
@@ -64,12 +62,13 @@ def make_combination(mitama_data, mitama_type_limit={}, all_suit=True):
                 secondary_mitama[i] = filter(lambda x: filter_mitama_by_type(x, secondary_type), mitama_data[i])
 
         res = []
+        #chosen type only
         total_comb += reduce(lambda x,y: x*y, map(len, main_mitama.values()))
         res.append(itertools.product(*main_mitama.values()))
 
         #4+2
         for i in range(1, 7):
-            for j in range(i, 7):
+            for j in range(i+1, 7):
                 mitama_grp = {x: main_mitama[x] for x in range(1,7)}
                 if secondary_type:
                     mitama_grp[i] = secondary_mitama[i]

--- a/calculator_of_Onmyoji/cal_mitama.py
+++ b/calculator_of_Onmyoji/cal_mitama.py
@@ -4,9 +4,12 @@
 import argparse
 import platform
 
-from calculator_of_Onmyoji import cal_and_filter as cal
-from calculator_of_Onmyoji import load_data
-from calculator_of_Onmyoji import write_data
+import cal_and_filter as cal
+import load_data
+import write_data
+# from calculator_of_Onmyoji import cal_and_filter as cal
+# from calculator_of_Onmyoji import load_data
+# from calculator_of_Onmyoji import write_data
 
 
 def str2bool(v):
@@ -140,10 +143,12 @@ def main():
     locate_sep_data = load_data.sep_mitama_by_loc(origin_data)
 
     print('Start calculating')
-    mitama_comb = cal.filter_loc2make_combination(locate_sep_data,
-                                                  l2_prop, int(l2_prop_value),
-                                                  l4_prop, int(l4_prop_value),
-                                                  l6_prop, int(l6_prop_value))
+    locate_sep_data = cal.filter_loc(locate_sep_data,
+                                  l2_prop, int(l2_prop_value),
+                                  l4_prop, int(l4_prop_value),
+                                  l6_prop, int(l6_prop_value))
+
+    mitama_comb = cal.make_combination(locate_sep_data, mitama_type_limit, args.all_suit)
 
     filter_result = cal.filter_mitama(mitama_comb,
                                       mitama_type_limit,

--- a/calculator_of_Onmyoji/cal_mitama.py
+++ b/calculator_of_Onmyoji/cal_mitama.py
@@ -4,12 +4,9 @@
 import argparse
 import platform
 
-import cal_and_filter as cal
-import load_data
-import write_data
-# from calculator_of_Onmyoji import cal_and_filter as cal
-# from calculator_of_Onmyoji import load_data
-# from calculator_of_Onmyoji import write_data
+from calculator_of_Onmyoji import cal_and_filter as cal
+from calculator_of_Onmyoji import load_data
+from calculator_of_Onmyoji import write_data
 
 
 def str2bool(v):


### PR DESCRIPTION
改了一下make_combination，如果用户选择了4件套的御魂，在生成组合之前过滤选中的御魂类型（即指定某4个位置只使用选中的御魂），可以大幅减少计算量。试了一下帖子#221楼大佬的御魂库，攻攻暴伤破势的组合数可以从226540800减少到53857236，